### PR TITLE
Replaced angle brackets with backticks

### DIFF
--- a/core-input.html
+++ b/core-input.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
  *
  *     <core-input multiline placeholder="Enter multiple lines here"></core-input>
  *
- * The text input's value is considered "committed" if the user hits the <enter>
+ * The text input's value is considered "committed" if the user hits the `enter`
  * key or blurs the input after changing the value. The "change" event is fired
  * when the value becomes committed, and the committed value is stored in the
  * "value" property. The current value of the input is stored in the "inputValue"
@@ -54,7 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 /**
  * Fired when the user commits the value of the input, either by the hitting the
- * <enter> key or blurring the input after the changing the inputValue. Also see the
+ * `enter` key or blurring the input after the changing the inputValue. Also see the
  * DOM "change" event.
  *
  * @event change
@@ -143,7 +143,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       /**
        * The value of the input committed by the user, either by changing the
-       * inputValue and blurring the input, or by hitting the <enter> key.
+       * inputValue and blurring the input, or by hitting the `enter` key.
        *
        * @attribute value
        * @type string


### PR DESCRIPTION
Right now <enter> doesn't show up on the docs, so angle brackets were replaced with backticks.
