### PR TITLE
Add validation for types : number, email and url

### DIFF
--- a/core-input.html
+++ b/core-input.html
@@ -89,7 +89,7 @@ Fired when the inputValue of this text input changes and passes validation.
     </template>
 
     <template if="{{!multiline}}">
-      <input id="input" value="{{inputValue}}" disabled?="{{disabled}}" type="{{type}}" placeholder="{{placeholder}}" required?="{{required}}" readonly?="{{readonly}}" aria-label="{{label || placeholder}}" aria-invalid="{{invalid}}" on-change="{{inputChangeAction}}" on-focus="{{inputFocusAction}}" on-blur="{{inputBlurAction}}">
+      <input id="input" value="{{inputValue}}" disabled?="{{disabled}}" type="{{intType}}" placeholder="{{placeholder}}" required?="{{required}}" readonly?="{{readonly}}" aria-label="{{label || placeholder}}" aria-invalid="{{invalid}}" on-change="{{inputChangeAction}}" on-focus="{{inputFocusAction}}" on-blur="{{inputBlurAction}}">
     </template>
 
   </template>
@@ -107,7 +107,7 @@ Fired when the inputValue of this text input changes and passes validation.
          * @default ''
          */
         placeholder: '',
-  
+
         /**
          * If true, this input cannot be focused and the user cannot change
          * its value.
@@ -117,13 +117,14 @@ Fired when the inputValue of this text input changes and passes validation.
          * @default false
          */
         disabled: false,
-  
+
         /**
          * Set the input type. Not supported for `multiline`.
+         * Supported value : 'text', 'password', 'number', 'email', 'url'
          *
          * @attribute type
          * @type string
-         * @default text
+         * @default 'text'
          */
         type: 'text',
 
@@ -144,8 +145,8 @@ Fired when the inputValue of this text input changes and passes validation.
          * @default false
          */
         required: false,
-        
-        /**
+
+       /**
          * If true, this input accepts multi-line input like a `<textarea>`
          *
          * @attribute multiline
@@ -153,7 +154,7 @@ Fired when the inputValue of this text input changes and passes validation.
          * @default false
          */
         multiline: false,
-  
+
         /**
          * (multiline only) The height of this text input in rows. The input
          * will scroll internally if more input is entered beyond the size
@@ -166,7 +167,7 @@ Fired when the inputValue of this text input changes and passes validation.
          * @default 'fit'
          */
         rows: 'fit',
-  
+
         /**
          * The current value of this input. Changing inputValue programmatically
          * will cause value to be out of sync. Instead, change value directly
@@ -177,7 +178,7 @@ Fired when the inputValue of this text input changes and passes validation.
          * @default ''
          */
         inputValue: '',
-  
+
         /**
          * The value of the input committed by the user, either by changing the
          * inputValue and blurring the input, or by hitting the `enter` key.
@@ -187,7 +188,7 @@ Fired when the inputValue of this text input changes and passes validation.
          * @default ''
          */
         value: '',
-  
+
         /**
          * If this property is not null, the text input's inputValue will be
          * validated. You can validate the value with either a regular expression
@@ -202,14 +203,14 @@ Fired when the inputValue of this text input changes and passes validation.
          * Example:
          *
          *     // valid only if the value is a number
-         *     <core-input validate="^[0-9]*$"></core-input> 
-         * 
+         *     <core-input validate="^[0-9]*$"></core-input>
+         *
          *     // valid only if the value is a number
          *     this.$.input.validate = /^[0-9]*$/;
          *
          *     this.$.input2.validate = function(value) {
          *         // valid only if the value is 'foo'
-         *         return value === 'foo';  
+         *         return value === 'foo';
          *     }
          *
          * @attribute validate
@@ -217,7 +218,7 @@ Fired when the inputValue of this text input changes and passes validation.
          * @default null
          */
         validate: null,
-  
+
         /**
          * If this property is true, the text input's inputValue failed validation.
          *
@@ -225,11 +226,14 @@ Fired when the inputValue of this text input changes and passes validation.
          * @type boolean
          * @default false
          */
-        invalid: false,
+        invalid: false
       },
+
+      intType: null,
 
       ready: function() {
         this.tabindexChanged(this.getAttribute('tabindex'));
+        this.typeChanged();
       },
 
       validateValue: function() {
@@ -260,9 +264,7 @@ Fired when the inputValue of this text input changes and passes validation.
       },
 
       inputValueChanged: function() {
-        if (this.validate || this.required) {
-          this.validateValue();
-        }
+        this.validateValue();
       },
 
       valueChanged: function() {
@@ -292,8 +294,54 @@ Fired when the inputValue of this text input changes and passes validation.
        *
        * @method commit
        */
+      commit: function()
+      {
+          this.value = this.inputValue;
+      },
+
+      typeChanged: function() {
+        if (this.multiline) { // type not supported for `multiline`
+          return;
+        }
+
+        this.type = typeof this.type === 'string' ? this.type.toLowerCase() : this.type;
+
+        this.validate = this.validate || CoreInput.validate[this.type];
+        if (this.validate === undefined) {
+          console.error('Unknown type : ' + this.type);
+          this.type = 'text';
+          this.validate = null;
+        }
+
+        this.intType = this.type == 'password' ? this.type : 'text';
+	    this.validateValue();
+      },
+
+      requiredChanged: function() {
+        this.validateValue();
+      },
+
+      attributeChanged: function(attr, oldVal, curVal) {
+        if (attr === 'tabindex') {
+          this.tabindexChanged(curVal);
+        }
+      },
+
+      tabindexChanged: function(tabindex) {
+        if (tabindex > 0) {
+          this.$.input.setAttribute('tabindex', -1);
+        } else {
+          this.$.input.removeAttribute('tabindex');
+        }
+      },
+
+      /**
+       * Commits the inputValue to value.
+       *
+       * @method commit
+       */
       commit: function() {
-         this.value = this.inputValue;
+        this.value = this.inputValue;
       },
 
       inputChangeAction: function() {
@@ -370,8 +418,13 @@ Fired when the inputValue of this text input changes and passes validation.
       return document.createElement('core-input');
     };
     CoreInput.validate = {
-      number: /^[0-9]*$/
+      text: null,
+      password: null,
+      number: /^(\-|\+)?(\d+|(\d*(\.\d*)))$/,
+      email: /^[a-z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-z0-9-]+(\.[a-z0-9-]+)*$/i,
+      url: /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/
     };
   </script>
 
 </polymer-element>
+

--- a/demo.html
+++ b/demo.html
@@ -69,13 +69,43 @@
 
   <section horizontal start layout>
     <aside>This is an example of a single-line password input. See console for committed values.</aside>
-    <core-input id="password" type="password" placeholder="Enter password..."></core-input>
+    <core-input id="single" type="password" placeholder="Enter password..."></core-input>
     <script>
-      var password = document.getElementById('password');
-      password.addEventListener('change', function() {
-        console.log('password: value committed: ', password.value);
+      var single = document.getElementById('single');
+      single.addEventListener('change', function() {
+        console.log('single: value committed: ', single.value);
       });
     </script>
+  </section>
+
+  <section horizontal start layout>
+    <aside>This is an example of a single-line number input. See console for committed values.</aside>
+    <core-input id="singleNumber" type="number" placeholder="Type only numbers..."></core-input>
+    <script>
+      document.getElementById('singleNumber').addEventListener('input-invalid', function(e, value, s) {
+        console.log('singleNumber: input invalid! value:', e.detail.value);
+      });
+    </script>
+  </section>
+
+  <section horizontal start layout>
+      <aside>This is an example of a single-line email input. See console for committed values.</aside>
+      <core-input id="singleEmail" type="email" placeholder="Enter email..."></core-input>
+      <script>
+        document.getElementById('singleEmail').addEventListener('input-invalid', function(e, value, s) {
+          console.log('singleEmail: input invalid! value:', e.detail.value);
+        });
+      </script>
+  </section>
+
+  <section horizontal start layout>
+      <aside>This is an example of a single-line url input. See console for committed values.</aside>
+      <core-input id="singleUrl" type="url" placeholder="Enter url..."></core-input>
+      <script>
+        document.getElementById('singleUrl').addEventListener('input-invalid', function(e, value, s) {
+          console.log('singleUrl: input invalid! value:', e.detail.value);
+        });
+      </script>
   </section>
 
   <section horizontal start layout>


### PR DESCRIPTION
Enable validation on `<core-input>` of types 'number', 'email' and 'url'.
Add 'trim' property - If set to `true` (default), the input is automatically trim.

Input validation according to type, prevent unwanted behaviour of : 
`<paper-input type="number" floatingLabel label="Type only numbers..."></paper-input>`
