### PR TITLE
fixed paper-input multiline textarea not growing in firefox

### DIFF
--- a/core-input.css
+++ b/core-input.css
@@ -32,4 +32,5 @@ textarea[fit] {
   left: 0;
   right: 0;
   bottom: 0;
+  height: 100%;
 }


### PR DESCRIPTION
the multiline textarea is not growing the way it should be in firefox.
see: http://www.polymer-project.org/components/paper-elements/demo.html#paper-input
